### PR TITLE
Prefer IEmitter type over Emitter in effect signatures

### DIFF
--- a/src/functions.ts
+++ b/src/functions.ts
@@ -1,5 +1,4 @@
-import { Emitter } from "./Emitter";
-import { IActionDefinition, IActionType } from "./types";
+import { IActionDefinition, IActionType, IEmitter } from "./types";
 
 export function defineAction<T>(type: string) {
   const definition: IActionDefinition<T> = ((payload: T) => ({ type, payload })) as any;
@@ -7,15 +6,15 @@ export function defineAction<T>(type: string) {
   return definition;
 }
 
-export function on<T>(emitter: Emitter, type: IActionType<T>, cb: (t: T) => void) {
+export function on<T>(emitter: IEmitter, type: IActionType<T>, cb: (t: T) => void) {
   return emitter.on(type, cb);
 }
 
-export function off<T>(emitter: Emitter, type: IActionType<T>, cb: (t: T) => void) {
+export function off<T>(emitter: IEmitter, type: IActionType<T>, cb: (t: T) => void) {
   return emitter.off(type, cb);
 }
 
-export function once<T>(emitter: Emitter, type: IActionType<T>, cb: (t: T) => void) {
+export function once<T>(emitter: IEmitter, type: IActionType<T>, cb: (t: T) => void) {
   const handler = (value: T) => {
     emitter.off(type, handler);
     cb(value);
@@ -25,9 +24,13 @@ export function once<T>(emitter: Emitter, type: IActionType<T>, cb: (t: T) => vo
   return { cancel: () => emitter.off(type, handler) };
 }
 
-export function take<T>(emitter: Emitter, type: IActionType<T>): Promise<T>;
-export function take<T>(emitter: Emitter, type: IActionType<T>, maxWait: number): Promise<T | null>;
-export function take<T>(emitter: Emitter, type: IActionType<T>, maxWait?: number) {
+export function take<T>(emitter: IEmitter, type: IActionType<T>): Promise<T>;
+export function take<T>(
+  emitter: IEmitter,
+  type: IActionType<T>,
+  maxWait: number,
+): Promise<T | null>;
+export function take<T>(emitter: IEmitter, type: IActionType<T>, maxWait?: number) {
   return new Promise<T | null>((resolve) => {
     const o = once(emitter, type, (value) => {
       if (handle !== 0) {


### PR DESCRIPTION
I would like to avoid exposing Class types in our utilities, just because it may cause annoying leakage or weird compatibility issues if anybody implements interfaces themselves.