### PR TITLE
Emit declaration files with esm build

### DIFF
--- a/tsconfig-esm.json
+++ b/tsconfig-esm.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "declaration": false,
+    "declaration": true,
     "importHelpers": true,
     "jsx": "react",
     "lib": ["dom", "es2015"],


### PR DESCRIPTION
We were mistakenly not emitting any `.d.ts` files, even though we had already set the `"typings"` package.json key.