### PR TITLE
Simplify Emitter API to talk only in IActions

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -18,14 +18,14 @@ export type IActionType<T> = string & {
 };
 
 export interface IEmitter {
-  emit(type: IActionType<undefined>): void;
-  emit<T>(type: IActionType<T>, payload: T): void;
-
+  emit(action: IAction): void;
   on<T>(type: IActionType<T>, handler: (payload: T) => void): void;
   off<T>(type: IActionType<T>, handler: (payload: T) => void): void;
 }
 
 export interface IViewStore<S> {
+  readonly state: S;
+
   getState(): S;
   setState(nextState: S): void;
   subscribe(cb: () => void): () => void;


### PR DESCRIPTION
Remit was originally going to lean into a channel-like API instead of an actions-like API, but since its value is in integrating with React-Redux and existing other Redux tools, we should probably lean more into the Actions flavor.